### PR TITLE
Add comprehensive support for account resolution and management handover

### DIFF
--- a/openid-provider-commands-1_0.md
+++ b/openid-provider-commands-1_0.md
@@ -1114,7 +1114,7 @@ This specification registers the `application/command+jwt` media type as per {{!
 - **[RFC8725]** Bromberg, L. “Security Considerations for JSON Web Tokens,” *RFC 8725*, June 2020.
 - **[RFC6838]** IANA. “Media Types,” *RFC 6838*, June 2013.
 - **ISO/IEC 24760-1:2019**, “IT Security – A framework for identity management – Part 1: Terminology and concepts.”
-- **OpenID.Core** – “OpenID Connect Core 1.0 incorporating errata set 1,” available at <https://openid.net/specs/openid-connect-core-1_0.html>.
+- **OpenID.Core** – “OpenID Connect Core 1.0 incorporating errata set 2,” available at <https://openid.net/specs/openid-connect-core-1_0.html>.
 - **OpenID.Enterprise** – "OpenID Connect Enterprise Extensions 1.0," available at <https://openid.net/specs/openid-connect-enterprise-extensions-1_0.html>.
 
 ## Informative References

--- a/openid-provider-commands-1_0.md
+++ b/openid-provider-commands-1_0.md
@@ -1137,16 +1137,6 @@ established by [RFC7519](#RFC7519).
 
 **Specification Document(s):** This document
 
-- **Claim Name:** `aud_sub`
-
-**Claim Description:**
-  The audience's internal identifier for the subject of the token, used for account resolution between identity providers and relying parties.
-  
-**Change Controller:** OpenID Foundation
-
-**Specification Document(s):** This document
-
-
 
 ## OAuth Dynamic Client Registration Metadata Registration
 

--- a/openid-provider-commands-1_0.md
+++ b/openid-provider-commands-1_0.md
@@ -542,7 +542,7 @@ The RP MAY include an `authentication_provider` claim that represents which part
 
 ## Invalidate Command
 
-Identified by the `invalidate` or `invalidate_audit` value in the `command` Claim in a Command Token.
+Identified by the `invalidate` or `invalidate_async` value in the `command` Claim in a Command Token.
 
 The RP MUST perform the [Invalidate Functionality](#invalidate-functionality) on the Account.
 The OP MAY send this Command when it suspects a previous OpenID Connect ID Token issued by the OP was granted to a malicious actor, if the user's device was compromised, or any other security related concern about the account. 


### PR DESCRIPTION
- Add 'manage' command to Abstract and Introduction command lists
- Add account management handover documentation to Command Usage Overview
- Add 'aud_sub' claim definition to Command Token section for account resolution
- Register 'aud_sub' and 'managed_by' claims in IANA JWT Claims registry
- Complete integration of account resolution features throughout specification

These changes enable OPs to take over management of existing RP accounts and provide efficient account lookup using RP internal identifiers.

#25 

see previous comments on old PR that I accidently closed from Karl

https://github.com/openid/openid-provider-commands/pull/27

Most of his comments have been incorporated in this PR

