### PR TITLE
chore: bump GitHub Actions to Node-24-compatible majors

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,13 +39,14 @@ jobs:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: '1.20'
+          cache: false
       
       - name: Install mmark
         run: go install github.com/mmarkdown/mmark@latest
@@ -56,13 +57,13 @@ jobs:
 
       - name: Upload XML artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generated-xml
           path: openid-provider-commands-1_0.xml    
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10' 
       - name: Install xml2rfc
@@ -87,7 +88,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: success()
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v5
         with:
           target_branch: gh-pages
           build_dir: html


### PR DESCRIPTION
## Why
GitHub is deprecating the Node 20 runtime for JS actions (runners force Node 24 on **2026-06-16**, Node 20 removed **2026-09-16**). This repo's `gh-pages.yml` pinned actions on Node 20 (and the Pages action on **Node 12**), which emit deprecation warnings now and break after those dates.

## Changes (`.github/workflows/gh-pages.yml`)
- `actions/checkout` v3 → **v6**
- `actions/setup-go` v3 → **v6** — added `cache: false` (repo has no `go.sum`; setup-go v4+ enables caching by default and would fail the step without a lock file)
- `actions/setup-python` v4 → **v6**
- `actions/upload-artifact` v4 → **v7**
- `crazy-max/ghaction-github-pages` v2 (**node12**) → **v5** (**node24**) — inputs (`target_branch`, `build_dir`, `keep_history`) unchanged across majors

## Validation
- `actionlint` clean on all bumped lines. Remaining actionlint notes (unquoted `$BRANCH_NAME` SC2086, leftover `steps.deployment` reference) are **pre-existing** and out of scope for this Node-24 sweep.
- Not test-deployed: the `push` trigger has `paths-ignore: .github/**`, so this branch does **not** trigger the Pages deploy. Workflow logic is unchanged apart from action majors — review by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)